### PR TITLE
ngfw-14960 updated references to untangle domains with Arista domain

### DIFF
--- a/cd-root/README.html
+++ b/cd-root/README.html
@@ -38,7 +38,7 @@
               <br/>
               <br/>
               <div style="text-align: center;">
-                <a href="http://www.edge.arista.com">Untangle Home Page</a>
+                <a href="http://edge.arista.com">Untangle Home Page</a>
               </div>
               
               <br/>

--- a/cd-root/README.html
+++ b/cd-root/README.html
@@ -38,13 +38,13 @@
               <br/>
               <br/>
               <div style="text-align: center;">
-                <a href="http://www.untangle.com">Untangle Home Page</a>
+                <a href="http://www.edge.arista.com">Untangle Home Page</a>
               </div>
               
               <br/>
               <br/>
               <div style="text-align: center;">
-                <a href="http://wiki.untangle.com/images/8/82/Untangle_Quickstart_Guide.pdf">Quickstart Guide</a>
+                <a href="http://wiki.edge.arista.com/images/8/82/Untangle_Quickstart_Guide.pdf">Quickstart Guide</a>
               </div>
               
             </td>

--- a/cd-root/README.txt
+++ b/cd-root/README.txt
@@ -2,5 +2,5 @@ Untangle
 
 Reboot and boot from this media to begin installation.
 
-Untangle Home Page http://www.edge.arista.com/
+Untangle Home Page http://edge.arista.com/
 Documentation http://wiki.edge.arista.com/

--- a/cd-root/README.txt
+++ b/cd-root/README.txt
@@ -2,5 +2,5 @@ Untangle
 
 Reboot and boot from this media to begin installation.
 
-Untangle Home Page http://www.untangle.com/
-Documentation http://wiki.untangle.com/
+Untangle Home Page http://www.edge.arista.com/
+Documentation http://wiki.edge.arista.com/

--- a/cloud/files/etc/apt/sources.list.d/untangle.list/UNTANGLE
+++ b/cloud/files/etc/apt/sources.list.d/untangle.list/UNTANGLE
@@ -1,3 +1,3 @@
 deb {untangle_mirror} {untangle_release} main non-free
-# deb http://foo:untangle@updates.untangle.com/public/jessie beat main non-free
+# deb http://foo:untangle@updates.edge.arista.com/public/jessie beat main non-free
 # deb http://localhost:8080/public/jessie chaos main non-free


### PR DESCRIPTION
**Changes:** Replaced references to untangle domains with Arista domain.
**Document:** [Servers and Domains](https://awakesecurity.atlassian.net/wiki/spaces/IT/pages/2830860307/Servers+Domains+Certificates+IPs)